### PR TITLE
Add migration for markets, vendors, products, and market_vendors

### DIFF
--- a/db/migrations/20200218162919_initial.js
+++ b/db/migrations/20200218162919_initial.js
@@ -1,0 +1,50 @@
+
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('markets', (table) => {
+      table.increments('id').primary();
+      table.string('name');
+      table.string('address');
+      table.string('google_link');
+      table.string('schedule');
+      table.float('latitude');
+      table.float('longitude');
+
+      table.timestamps(true, true);
+    })
+    .createTable('vendors', (table) => {
+      table.increments('id').primary();
+      table.string('name');
+      table.string('description');
+      table.string('image_link');
+
+      table.timestamps(true, true);
+    })
+    .createTable('products', (table) => {
+      table.increments('id').primary();
+      table.string('name');
+      table.string('description');
+      table.float('price');
+      table.integer('vendor_id').unsigned();
+      table.foreign('vendor_id').references('vendors.id')
+
+      table.timestamps(true, true);
+    })
+    .createTable('market_vendors', (table) => {
+      table.increments('id').primary();
+      table.integer('market_id').unsigned();
+      table.foreign('market_id').references('markets.id')
+      table.integer('vendor_id').unsigned();
+      table.foreign('vendor_id').references('vendors.id')
+
+      table.timestamps(true, true);
+    })
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .dropTable('market_vendors')
+    .dropTable('products')
+    .dropTable('vendors')
+    .dropTable('markets')
+};


### PR DESCRIPTION
### What does this PR do?
 - This PR changes adds table migrations for markets, vendors, products, and market_vendors

### How to test?
 - No tests currently

### Issues:
- NA

### Notes:
- We can start testing GraphQL


### Relevant Screenshots:
- NA

Co-Authored-By: Jessie Le-Ho <jessiethanh.02@gmail.com>

closes #21 
closes #20 
closes #15 
closes #14 