### PR TITLE
Add GraphQL support for Markets

### DIFF
--- a/db/seeds/dev/dev_seeds.js
+++ b/db/seeds/dev/dev_seeds.js
@@ -1,0 +1,28 @@
+
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex.raw('TRUNCATE TABLE markets CASCADE')
+    .then(() => { return Promise.all([
+      knex('markets').insert([
+        {
+          name: "market_1",
+          address: "address_1",
+          google_link: "google_link_1",
+          schedule: "schedule_1",
+          latitude: 1.1,
+          longitude: 2.1
+        },
+        {
+          name: "market_2",
+          address: "address_2",
+          google_link: "google_link_2",
+          schedule: "schedule_2",
+          latitude: 1.2,
+          longitude: 2.2
+        }
+      ], 'id')
+    ])
+  })
+  .then(() => console.log('Seeding Complete!'))
+  .catch(error => console.error(`Oops! Error seeding data: ${error}`));
+};

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 const express = require('express');
 const app = express();
-// Allows express to understand graphql and interact with graphql API
-// It is used as middleware for a single route
 const graphqlHTTP = require('express-graphql')
 const schema = require('./lib/schema/schema')
 
 
-app.use('/graphql-pets', graphqlHTTP({
+app.use('/graphql', graphqlHTTP({
   schema: schema,
   graphiql: true
 }))

--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -9,76 +9,39 @@ const {
   GraphQLString,
   GraphQLID,
   GraphQLInt,
+  GraphQLFloat,
   GraphQLList,
   GraphQLSchema,
   GraphQLNonNull
 } = graphql;
 
-const PetType = new GraphQLObjectType({
-  name: 'Pet',
+const MarketType = new GraphQLObjectType({
+  name: 'Market',
   fields: () => ({
-    id:             { type: GraphQLID },
-    name:           { type: GraphQLString },
-    animal_type:    { type: GraphQLString },
-    breed:          { type: GraphQLString },
-    age:            { type: GraphQLInt },
-    favorite_treat: { type: GraphQLString },
-    owner: {
-      type: OwnerType,
-      resolve(parent,args) {
-        return database('pets')
-          .join('owners', { 'pets.owner_id': 'owners.id' })
-          .where('owners.id', parent.owner_id)
-          .first()
-      }
-    }
+    id:          { type: GraphQLID },
+    name:        { type: GraphQLString },
+    address:     { type: GraphQLString },
+    google_link: { type: GraphQLString },
+    schedule:    { type: GraphQLString },
+    latitude:    { type: GraphQLFloat },
+    longitude:   { type: GraphQLFloat } 
   })
 });
-
-const OwnerType = new GraphQLObjectType({
-  name: "Owner",
-  fields: () => ({
-    id:   { type: GraphQLID },
-    name: { type: GraphQLString },
-    age:  { type: GraphQLInt },
-    pets: {
-      type: GraphQLList(PetType),
-      resolve(parent, args){
-        return database('owners')
-          .join('pets', { 'owners.id': 'pets.owner_id' })
-          .where('pets.owner_id', parent.id)
-      }
-    }
-  })
-})
 
 const RootQuery = new GraphQLObjectType({
   name: 'RootQuery',
   fields: {
-    pet: {
-      type: PetType,
+    market: {
+      type: MarketType,
       args: { id: { type: GraphQLID } },
       resolve(parent, args) {
-        return database('pets').where('id', args.id).first()
+        return database('markets').where('id', args.id).first()
       }
     },
-    pets: {
-      type: new GraphQLList(PetType),
+    markets: {
+      type: new GraphQLList(MarketType),
       resolve(parent, args) {
-        return database('pets').select()
-      }
-    },
-    owner: {
-      type: OwnerType,
-      args: { id: { type: GraphQLID } },
-      resolve(parent, args) {
-        return database('owners').where('id', args.id).first()
-      }
-    },
-    owners: {
-      type: GraphQLList(OwnerType),
-      resolve(parent, args) {
-        return database('owners').select()
+        return database('markets').select()
       }
     }
   }
@@ -87,18 +50,28 @@ const RootQuery = new GraphQLObjectType({
 const Mutation = new GraphQLObjectType({
   name: "Mutation",
   fields: {
-    addOwner: {
-      type: OwnerType,
+    addMarket: {
+      type: MarketType,
       args: {
-        name: {type: GraphQLNonNull(GraphQLString)},
-        age:  {type: GraphQLNonNull(GraphQLInt)}
+        id:          { type: GraphQLInt },
+        name:        { type: GraphQLString },
+        address:     { type: GraphQLString },
+        google_link: { type: GraphQLString },
+        schedule:    { type: GraphQLString },
+        latitude:    { type: GraphQLFloat },
+        longitude:   { type: GraphQLFloat } 
       },
       resolve(parent, args) {
-        return database('owners')
+        return database('markets')
         .returning('*')
         .insert({
-          name: args.name,
-          age:  args.age
+          id:          args.id,
+          name:        args.name,
+          address:     args.address,
+          google_link: args.google_link,
+          schedule:    args.schedule,
+          latitude:    args.latitude,
+          longitude:   args.longitude 
         })
         .then(result => result[0])
         .catch(error => error)
@@ -108,49 +81,7 @@ const Mutation = new GraphQLObjectType({
       type: GraphQLString,
       args: { id: { type: GraphQLNonNull(GraphQLID) } },
       resolve(parent, args){
-        return database('owners')
-        .where('id', args.id)
-        .del()
-        .then((result) => {
-          if(result == 1){
-            return "Success!"
-          } else {
-            return "Something went wrong, please check the id and try again."
-          }
-        })
-        .catch(error => error)
-      }
-    },
-    addPet: {
-      type: PetType,
-      args: {
-        name:           { type: GraphQLNonNull(GraphQLString) },
-        age:            { type: GraphQLNonNull(GraphQLInt) },
-        animal_type:    { type: GraphQLNonNull(GraphQLString) },
-        breed:          { type: GraphQLNonNull(GraphQLString) },
-        favorite_treat: { type: GraphQLNonNull(GraphQLString) },
-        owner_id:       { type: GraphQLNonNull(GraphQLID) }
-      },
-      resolve(parent, args){
-        return database('pets')
-        .returning('*')
-        .insert({
-          name:           args.name,
-          age:            args.age,
-          animal_type:    args.animal_type,
-          breed:          args.breed,
-          favorite_treat: args.favorite_treat,
-          owner_id:       args.owner_id
-        })
-        .then(result => result[0])
-        .catch(error => error)
-      }
-    },
-    deletePet:{
-      type: GraphQLString,
-      args: { id: { type: GraphQLNonNull(GraphQLID) } },
-      resolve(parent, args){
-        return database('pets')
+        return database('markets')
         .where('id', args.id)
         .del()
         .then((result) => {


### PR DESCRIPTION
### What does this PR do?
- This PR changes adds GraphQL support for markets
- Market(s) can be queried using GraphQL
- A Market can be added to the database using GraphQL
- A Market can be deleted from the database by its id
- Add a couple markets to the development seed file

### How to test?
- Currently no TDD
- From the root directory, run the command `node index.js`
- Open the browser to `http://localhost:3001/graphql`
- Use GraphQL queries to test the functionality defined within `/lib/schema/schema.js`

### Issues:
- ID is mandatory for creating a market

### Notes:
- This does not have any relationships set up


### Relevant Screenshots:
- NA

closes #23 
closes #24 
closes #25 