### PR TITLE
Add Vendor Field to Market GraphQL Query

### DIFF
--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -24,7 +24,16 @@ const MarketType = new GraphQLObjectType({
     google_link: { type: GraphQLString },
     schedule:    { type: GraphQLString },
     latitude:    { type: GraphQLFloat },
-    longitude:   { type: GraphQLFloat } 
+    longitude:   { type: GraphQLFloat },
+    vendors: {
+      type: GraphQLList(VendorType),
+      resolve(parent, args) {
+        return database('markets')
+          .join('market_vendors', { 'markets.id': 'market_vendors.market_id' })
+          .join('vendors', { 'market_vendors.vendor_id': 'vendors.id'} )
+          .where('market_vendors.market_id', parent.id)
+      }
+    }
   })
 });
 
@@ -35,6 +44,31 @@ const VendorType = new GraphQLObjectType({
     name:        { type: GraphQLString },
     description: { type: GraphQLString },
     image_link:  { type: GraphQLString }
+  })
+});
+
+const MarketVendorType = new GraphQLObjectType({
+  name: 'MarketVendor',
+  fields: () => ({
+    id: { type: GraphQLID },
+    market: {
+      type: MarketType,
+      resolve(parent, args) {
+        return database('market_vendors')
+          .join('markets', { 'market_vendors.market_id': 'markets.id'})
+          .where('markets.id', parent.market_id)
+          .first()
+      }
+    },
+    vendor: {
+      type: VendorType,
+      resolve(parent, args) {
+        return database('market_vendors')
+          .join('vendors', { 'market_vendors.vendor_id': 'vendors.id'})
+          .where('vendors.id', parent.vendor_id)
+          .first()
+      }
+    }
   })
 });
 
@@ -65,6 +99,12 @@ const RootQuery = new GraphQLObjectType({
       type: new GraphQLList(VendorType),
       resolve(parent, args) {
         return database('vendors').select()
+      }
+    },
+    market_vendors: {
+      type: new GraphQLList(MarketVendorType),
+      resolve(parent, args) {
+        return database('market_vendors').select()
       }
     }
   }
@@ -104,15 +144,21 @@ const Mutation = new GraphQLObjectType({
       type: GraphQLString,
       args: { id: { type: GraphQLNonNull(GraphQLID) } },
       resolve(parent, args){
-        return database('markets')
-        .where('id', args.id)
+        return database('market_vendors')
+        .where('market_id', args.id)
         .del()
-        .then((result) => {
-          if(result == 1){
-            return "Success!"
-          } else {
-            return "Something went wrong, please check the id and try again."
-          }
+        .then(() => {
+          return database('markets')
+          .where('id', args.id)
+          .del()
+          .then((result) => {
+            if(result == 1){
+              return "Success!"
+            } else {
+              return "Something went wrong, please check the id and try again."
+            }
+          })
+          .catch(error => error)
         })
         .catch(error => error)
       }
@@ -139,8 +185,48 @@ const Mutation = new GraphQLObjectType({
     deleteVendor: {
       type: GraphQLString,
       args: { id: { type: GraphQLNonNull(GraphQLID) } },
+      resolve(parent, args) {
+        return database('market_vendors')
+        .where('vendor_id', args.id)
+        .del()
+        .then(() => {
+          return database('vendors')
+          .where('id', args.id)
+          .del()
+          .then((result) => {
+            if(result == 1) {
+              return "Success!"
+            } else {
+              return "Something went wrong, please check the id and try again."
+            }
+          })
+          .catch(error => error)
+        })
+        .catch(error => error)
+      }
+    },
+    addMarketVendor: {
+      type: MarketVendorType,
+      args: {
+        market_id: { type: GraphQLNonNull(GraphQLID) },
+        vendor_id: { type: GraphQLNonNull(GraphQLID) }
+      },
+      resolve(parent, args) {
+        return database('market_vendors')
+        .returning('*')
+        .insert({
+          market_id: args.market_id,
+          vendor_id: args.vendor_id
+        })
+        .then(result => result[0])
+        .catch(error => error)
+      }
+    },
+    deleteMarketVendor: {
+      type: GraphQLString,
+      args: { id: { type: GraphQLNonNull(GraphQLID) } },
       resolve(parent, args){
-        return database('vendors')
+        return database('market_vendors')
         .where('id', args.id)
         .del()
         .then((result) => {


### PR DESCRIPTION
### What does this PR do?
- Adds a field to the market(s) query to list all vendors registered to a market
- Add add/delete mutations for market_vendors in order for a vendor to (un)register to a market
- Ensure that market_vendor rows are deleted whenever a market or vendor is deleted in order to not violate foreign key constraints

### How to test?
- No formal test files currently
- Seed the database with `knex seed:run`
- Run `node index.js` to start the server
- Navigate to `http://localhost:3001/graphql`
- Use GraphQL queries/mutations defined in `/lib/schema/schema.js`

### Issues:
- A vendor can register (via `addMarketVendor`) multiple times. This should not happen.

### Notes:
- There is no seed for market_vendors table, so you will have to manually register vendors to markets with `addMarketVendor` GraphQL mutation

### Relevant Screenshots:
- NA

closes #36 