### PR TITLE
Market seeding

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const graphqlHTTP = require('express-graphql')
 
 
 
-var marketsRouter = require('./lib/routes/api/v1/markets')
+var marketsRouter = require('./lib/routes/api/v1/markets').router
 var graphqlRouter = require('./lib/routes/api/v1/graphql')
 
 app.use(express.json());

--- a/lib/routes/api/v1/markets.js
+++ b/lib/routes/api/v1/markets.js
@@ -33,7 +33,7 @@ async function getMarketInfo(market) {
 
   let retMarket = {
     id:          market.id,
-    name:        market.marketname,
+    name:        stripNumsFromName(market.marketname),
     address:     marketDetails.marketdetails.Address,
     google_link: marketDetails.marketdetails.GoogleLink,
     latitude:    parsedLatLong[0],
@@ -53,6 +53,17 @@ async function createOrUpdateMarkets(markets) {
     }
   }
 }
+
+function stripNumsFromName(name) {
+  let marketNameSplit = name.split(' ');
+  if (marketNameSplit[0].includes('.')) {
+    marketNameSplit.shift();
+    marketNameSplit = marketNameSplit.join(' ');
+  }
+  return marketNameSplit
+}
+// let marketNameSplit = market.marketname.split(' ');
+                
 
 const parseLatLong = (googleLink) => {
   const split = googleLink.split('=').pop().split('%')

--- a/lib/routes/api/v1/markets.js
+++ b/lib/routes/api/v1/markets.js
@@ -2,6 +2,10 @@ const express = require('express');
 const router = express.Router();
 const farmersMarketService = require('../../../services/farmersMarketService')
 
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
 router.get('/', (request, response) => {
   Promise.all([
     farmersMarketService.getMarketsByZip(request.query.zip) 
@@ -17,6 +21,7 @@ router.get('/', (request, response) => {
 
     Promise.all(promises)
     .then(results => {
+      createOrUpdateMarkets(results)
       response.status(200).json(results)
     })
   })    
@@ -27,15 +32,26 @@ async function getMarketInfo(market) {
   let parsedLatLong = parseLatLong(marketDetails.marketdetails.GoogleLink);
 
   let retMarket = {
-    id: market.id,
-    name: market.marketname,
-    address: marketDetails.marketdetails.Address,
+    id:          market.id,
+    name:        market.marketname,
+    address:     marketDetails.marketdetails.Address,
     google_link: marketDetails.marketdetails.GoogleLink,
-    latitude: parsedLatLong[0],
-    longitude: parsedLatLong[1],
-    schedule: marketDetails.marketdetails.Schedule,
+    latitude:    parsedLatLong[0],
+    longitude:   parsedLatLong[1],
+    schedule:    marketDetails.marketdetails.Schedule,
   }
   return retMarket
+}
+
+async function createOrUpdateMarkets(markets) {
+  for (var i = 0; i < markets.length; i++) {
+    let databaseMarket = await database('markets').where({id: markets[i].id}).first()
+    if (databaseMarket) {
+      await database('markets').where('id', markets[i].id).update(markets[i])
+    } else {
+      await database('markets').insert(markets[i])
+    }
+  }
 }
 
 const parseLatLong = (googleLink) => {
@@ -47,4 +63,4 @@ const parseLatLong = (googleLink) => {
 
 
 
-module.exports = router;
+module.exports = { router, createOrUpdateMarkets};

--- a/tests/requests/api/v1/markets.spec.js
+++ b/tests/requests/api/v1/markets.spec.js
@@ -1,6 +1,7 @@
 var shell = require('shelljs');
 var request = require("supertest");
 var app = require('../../../../index');
+var router = require('../../../../lib/routes/api/v1/markets')
 const environment = process.env.NODE_ENV || 'test';
 const configuration = require('../../../../knexfile')[environment];
 const database = require('knex')(configuration);
@@ -17,8 +18,7 @@ describe('Test The Market\'s Path', () => {
     let res = await request(app)
       .get('/api/v1/markets?zip=80203')
 
-    let markets = database('markets').select()
-
+      
     expect(res.statusCode).toBe(200)
     expect(res.body.length).toBe(19)
     expect(res.body[0]).toHaveProperty('id')
@@ -28,7 +28,57 @@ describe('Test The Market\'s Path', () => {
     expect(res.body[0]).toHaveProperty('schedule')
     expect(res.body[0]).toHaveProperty('latitude')
     expect(res.body[0]).toHaveProperty('longitude')
-    expect(markets.length).toBe(19)
-    
+  })
+
+  it('should update or create markets', async () => {
+    await database('markets').insert({
+      id: 1,
+      name: "name",
+      address: "address",
+      google_link: "google",
+      schedule: "schedule",
+      latitude: 1.1,
+      longitude: 1.2
+    })
+
+    let updateMarketParams = [
+      {
+        id: 1,
+        name: "new_name",
+        address: "new_address",
+        google_link: "new_google",
+        schedule: "new_schedule",
+        latitude: 50.1,
+        longitude: 50.2
+      },
+      {
+        id: 2,
+        name: "name",
+        address: "address",
+        google_link: "google",
+        schedule: "schedule",
+        latitude: 1.1,
+        longitude: 1.2
+      }
+    ]
+
+    await router.createOrUpdateMarkets(updateMarketParams)
+  
+    let market_1 = await database('markets').where({id: 1}).first()
+    let market_2 = await database('markets').where({id: 2}).first()
+
+    expect(market_1.name).toBe('new_name')
+    expect(market_1.address).toBe("new_address")
+    expect(market_1.google_link).toBe("new_google")
+    expect(market_1.schedule).toBe("new_schedule")
+    expect(market_1.latitude).toBe(50.1)
+    expect(market_1.longitude).toBe(50.2)
+
+    expect(market_2.name).toBe('name')
+    expect(market_2.address).toBe("address")
+    expect(market_2.google_link).toBe("google")
+    expect(market_2.schedule).toBe("schedule")
+    expect(market_2.latitude).toBe(1.1)
+    expect(market_2.longitude).toBe(1.2)
   })
 })

--- a/tests/requests/api/v1/markets.spec.js
+++ b/tests/requests/api/v1/markets.spec.js
@@ -6,25 +6,29 @@ const configuration = require('../../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Test The Market\'s Path', () => {
-    beforeEach(async () => {
-        await database.raw('TRUNCATE TABLE markets CASCADE')
-    })
-    afterEach(() => {
-        database.raw('TRUNCATE TABLE markets CASCADE')
-    })
+  beforeEach(async () => {
+    await database.raw('TRUNCATE TABLE markets CASCADE')
+  })
+  afterEach(() => {
+    database.raw('TRUNCATE TABLE markets CASCADE')
+  })
 
-    it('should test happy path', async () => {
-        let res = await request(app)
-        .get('/api/v1/markets?zip=80203')
+  it('should test happy path', async () => {
+    let res = await request(app)
+      .get('/api/v1/markets?zip=80203')
 
-        expect(res.statusCode).toBe(200)
-        expect(res.body.length).toBe(19)
-        expect(res.body[0]).toHaveProperty('id')
-        expect(res.body[0]).toHaveProperty('name')
-        expect(res.body[0]).toHaveProperty('address')
-        expect(res.body[0]).toHaveProperty('google_link')
-        expect(res.body[0]).toHaveProperty('schedule')
-        expect(res.body[0]).toHaveProperty('latitude')
-        expect(res.body[0]).toHaveProperty('longitude')
-    })
+    let markets = database('markets').select()
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body.length).toBe(19)
+    expect(res.body[0]).toHaveProperty('id')
+    expect(res.body[0]).toHaveProperty('name')
+    expect(res.body[0]).toHaveProperty('address')
+    expect(res.body[0]).toHaveProperty('google_link')
+    expect(res.body[0]).toHaveProperty('schedule')
+    expect(res.body[0]).toHaveProperty('latitude')
+    expect(res.body[0]).toHaveProperty('longitude')
+    expect(markets.length).toBe(19)
+    
+  })
 })


### PR DESCRIPTION
* Add creation of Markets from markets returned from the farmers market API
* Add update of Markets that exist in the database if the farmers market API had updated information on the market
* Strips the numbers from the market names from the farmers market API