### PR TITLE
Connect market vendors to vendors to show the markets that the vendor…

### DIFF
--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -51,6 +51,14 @@ const VendorType = new GraphQLObjectType({
           .join('products', { 'vendors.id': 'products.vendor_id'}) //check this line
           .where('products.vendor_id', parent.id)
       }
+    },
+    market_vendors: {
+      type: GraphQLList(MarketVendorType),
+      resolve(parent, args) {
+        return database('vendors')
+          .join('market_vendors', { 'vendors.id': 'market_vendors.market_id'})
+          .where('market_vendors.market_id', parent.id)
+      }
     }
   })
 });

--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -28,8 +28,7 @@ const MarketType = new GraphQLObjectType({
     vendors: {
       type: GraphQLList(VendorType),
       resolve(parent, args) {
-        return database('markets')
-          .join('market_vendors', { 'markets.id': 'market_vendors.market_id' })
+        return database('market_vendors')
           .join('vendors', { 'market_vendors.vendor_id': 'vendors.id'} )
           .where('market_vendors.market_id', parent.id)
       }
@@ -52,12 +51,12 @@ const VendorType = new GraphQLObjectType({
           .where('products.vendor_id', parent.id)
       }
     },
-    market_vendors: {
-      type: GraphQLList(MarketVendorType),
+    markets: {
+      type: GraphQLList(MarketType),
       resolve(parent, args) {
-        return database('vendors')
-          .join('market_vendors', { 'vendors.id': 'market_vendors.market_id'})
-          .where('market_vendors.market_id', parent.id)
+        return database('market_vendors')
+          .join('markets', { 'market_vendors.market_id': 'markets.id'})
+          .where('market_vendors.vendor_id', parent.id)
       }
     }
   })

--- a/tests/requests/api/v1/graphql.spec.js
+++ b/tests/requests/api/v1/graphql.spec.js
@@ -285,7 +285,7 @@ describe('Test The Market\'s Path', () => {
 
     it('should get all vendors', async () => {
       let res = await request(app)
-        .get('/api/v1/graphql?query=query{vendors{id name description image_link products { id }}}')
+        .get('/api/v1/graphql?query=query{vendors{id name description image_link products { id } markets { id } }}')
         
       expect(res.statusCode).toBe(200)
       expect(res.body).toHaveProperty('data')
@@ -299,6 +299,10 @@ describe('Test The Market\'s Path', () => {
       expect(res.body.data.vendors[0].image_link).toBe("vendor_1_image_link")
       expect(res.body.data.vendors[0]).toHaveProperty('products')
       expect(res.body.data.vendors[0].products.length).toBe(2)
+      expect(res.body.data.vendors[0]).toHaveProperty('markets')
+      expect(res.body.data.vendors[0].markets.length).toBe(2)
+
+
       
       expect(res.body.data.vendors[1]).toHaveProperty('id')
       expect(res.body.data.vendors[1]).toHaveProperty('name')
@@ -309,12 +313,14 @@ describe('Test The Market\'s Path', () => {
       expect(res.body.data.vendors[1].image_link).toBe("vendor_2_image_link")
       expect(res.body.data.vendors[1]).toHaveProperty('products')
       expect(res.body.data.vendors[1].products.length).toBe(3)
+      expect(res.body.data.vendors[1]).toHaveProperty('markets')
+      expect(res.body.data.vendors[1].markets.length).toBe(1)
     })
 
     it('should get a single vendor by id', async () => {
       const vendor = await database('vendors').select().first()
       let res = await request(app)
-        .get(`/api/v1/graphql?query=query{vendor(id: ${vendor.id}){id name description image_link products { id }}}`)
+        .get(`/api/v1/graphql?query=query{vendor(id: ${vendor.id}){id name description image_link products { id } markets { id } }}`)
         
       expect(res.statusCode).toBe(200)
       expect(res.body).toHaveProperty('data')
@@ -327,6 +333,8 @@ describe('Test The Market\'s Path', () => {
       expect(res.body.data.vendor.image_link).toBe("vendor_1_image_link")
       expect(res.body.data.vendor).toHaveProperty('products')
       expect(res.body.data.vendor.products.length).toBe(2)
+      expect(res.body.data.vendor).toHaveProperty('markets')
+      expect(res.body.data.vendor.markets.length).toBe(2)
     })
 
     it('should get all products', async () => {


### PR DESCRIPTION
### What does this PR do?
- Connect market vendors to vendors to show which markets the vendors have worked/work with.

### How to test?
- run the command `npm test tests/requests/api/v1/graphql.spec.js` in the root directory

### Issues:

### Notes:

### Relevant Screenshots:
- NA
