### PR TITLE
Graphql Hotfix

### DIFF
--- a/lib/routes/api/v1/graphql.js
+++ b/lib/routes/api/v1/graphql.js
@@ -10,8 +10,8 @@ const { graphql } = require('graphql')
 // )
 
 router.get('/', (req, res) => {
-  let query = req.query.query.toLowerCase()
-  if (query[0] != "q") {
+  let query = req.query.query.trim()
+  if (query[0].toLowerCase() != "q") {
     res.status(405).json({message: "Mutation body must start with 'query'!"})
   } else {
     graphql(schema, req.query.query)
@@ -22,8 +22,8 @@ router.get('/', (req, res) => {
 })
 
 router.post('/', (req, res) => {
-  let query = req.body.query.toLowerCase()
-  if (query[0] != "m") {
+  let query = req.body.query.trim()
+  if (query[0].toLowerCase() != "m") {
     res.status(405).json({message: "Mutation body must start with 'mutation'!"})
   } else {
     graphql(schema, req.body.query)

--- a/tests/requests/api/v1/graphql.spec.js
+++ b/tests/requests/api/v1/graphql.spec.js
@@ -196,6 +196,29 @@ describe('Test The Market\'s Path', () => {
         expect(res.body.message).toBe("Mutation body must start with 'mutation'!")
       })
 
+      it('query strips leading whitespace', async () => {
+        let name = "newVendor"
+        let description = "vendorDescription"
+        let image = "https://vendor.com/vendor.jpg"
+        let res = await request(app)
+          .post('/api/v1/graphql')
+          .send({
+            query: ` 
+              mutation {
+                addVendor(
+                  name: "${name}",
+                  description: "${description}",
+                  image_link: "${image}"
+                ) {
+                  id
+                }
+              }
+            `
+          })
+
+        expect(res.statusCode).toBe(201)
+      })
+
       it('query must be free of syntax errors', async () => {
         const queryString = 'mutation{addVendor(name: "newVendor", description: "vendorDescription", image_link: "https://vendor.com/vendor.jpg"){id'
         let res = await request(app)


### PR DESCRIPTION
* Trim whitespace from the beginning of the query in both the POST and GET endpoints of `/api/v1/graphql` so that the query doesn't have to be as specific