### PR TITLE
Add Market Search Sad Paths

### DIFF
--- a/lib/routes/api/v1/markets.js
+++ b/lib/routes/api/v1/markets.js
@@ -7,24 +7,31 @@ const configuration = require('../../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 router.get('/', (request, response) => {
-  Promise.all([
-    farmersMarketService.getMarketsByZip(request.query.zip) 
-  ])
-  .then((marketIds) => {
-    let promises = []
-
-    results = marketIds[0].results
-
-    results.forEach(market => {
-      promises.push(getMarketInfo(market))
-    })
-
-    Promise.all(promises)
-    .then(results => {
-      createOrUpdateMarkets(results)
-      response.status(200).json(results)
-    })
-  })    
+  if (isNaN(request.query.zip)) {
+    response.status(404).json({ message: "That zip code does not exist!" })
+  } else if (request.query.zip.length != 5){
+    response.status(400).json({ message: "Invalid zip format!" })
+  } else {
+    Promise.all([
+      farmersMarketService.getMarketsByZip(request.query.zip) 
+    ])
+    .then((marketIds) => {
+      let promises = []
+  
+      results = marketIds[0].results
+  
+      results.forEach(market => {
+        promises.push(getMarketInfo(market))
+      })
+  
+      Promise.all(promises)
+      .then(results => {
+        createOrUpdateMarkets(results)
+        response.status(200).json(results)
+      })
+    })  
+  }
+    
 })
 
 async function getMarketInfo(market) {

--- a/tests/requests/api/v1/markets.spec.js
+++ b/tests/requests/api/v1/markets.spec.js
@@ -30,6 +30,26 @@ describe('Test The Market\'s Path', () => {
     expect(res.body[0]).toHaveProperty('longitude')
   })
 
+  describe('should test sad path', () => {
+    it('zip should be a number', async () => {
+      let res = await request(app)
+        .get('/api/v1/markets?zip=asdf')
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty('message')
+      expect(res.body.message).toBe("That zip code does not exist!")
+    })
+
+    it('zip should be only five numbers', async () => {
+      let res = await request(app)
+        .get('/api/v1/markets?zip=8000')
+
+      expect(res.statusCode).toBe(400)
+      expect(res.body).toHaveProperty('message')
+      expect(res.body.message).toBe("Invalid zip format!")
+    })
+  })
+
   it('should update or create markets', async () => {
     await database('markets').insert({
       id: 1,


### PR DESCRIPTION
* Add a sad path response (status 404) for when a user searches for markets with letters in the zip
* Add a sad path response (status 400) for when a user searches for markets with an invalid zip code (i.e. more/less than five numbers)

closes #8 
closes #7 