### PR TITLE
GraphQL Mutation - Delete All Vendor Products

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,14 @@ This endpoint requires a body with one of the following formats:
 {
   "query": "
     mutation {
+      deleteMarket(id: <int>)
+    }
+  "
+}
+
+{
+  "query": "
+    mutation {
       addVendor(
         name: <string>,
         description: <string>,
@@ -329,6 +337,14 @@ This endpoint requires a body with one of the following formats:
           price
         }
       }
+    }
+  "
+}
+
+{
+  "query": "
+    mutation {
+      deleteVendor(id: <int>)
     }
   "
 }
@@ -360,6 +376,14 @@ This endpoint requires a body with one of the following formats:
 {
   "query": "
     mutation {
+      deleteProduct(id: <int>)
+    }
+  "
+}
+
+{
+  "query": "
+    mutation {
       addMarketVendor(
         market_id: <int>,
         vendor_id: <int>
@@ -368,6 +392,22 @@ This endpoint requires a body with one of the following formats:
         market
         vendor
       }
+    }
+  "
+}
+
+{
+  "query": "
+    mutation {
+      deleteMarketVendor(id: <int>)
+    }
+  "
+}
+
+{
+  "query": "
+    mutation {
+      deleteAllVendorProducts(id: <int>)
     }
   "
 }

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ This endpoint requires a body with one of the following formats:
 {
   "query": "
     mutation {
-      deleteMarket(id: <int>)
+      deleteMarket(id: <market_id>)
     }
   "
 }
@@ -344,7 +344,7 @@ This endpoint requires a body with one of the following formats:
 {
   "query": "
     mutation {
-      deleteVendor(id: <int>)
+      deleteVendor(id: <vendor_id>)
     }
   "
 }
@@ -376,7 +376,7 @@ This endpoint requires a body with one of the following formats:
 {
   "query": "
     mutation {
-      deleteProduct(id: <int>)
+      deleteProduct(id: <product_id>)
     }
   "
 }
@@ -399,7 +399,7 @@ This endpoint requires a body with one of the following formats:
 {
   "query": "
     mutation {
-      deleteMarketVendor(id: <int>)
+      deleteMarketVendor(id: <market_vendor_id>)
     }
   "
 }
@@ -407,7 +407,7 @@ This endpoint requires a body with one of the following formats:
 {
   "query": "
     mutation {
-      deleteAllVendorProducts(id: <int>)
+      deleteAllVendorProducts(id: <vendor_id>)
     }
   "
 }

--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -324,6 +324,18 @@ const Mutation = new GraphQLObjectType({
         .catch(error => error)
       }
     },
+    deleteAllVendorProducts: {
+      type: GraphQLString,
+      args: { id: {type: GraphQLNonNull(GraphQLID) } },
+      resolve(parent, args) {
+        return database('products')
+        .where('vendor_id', args.id)
+        .del()
+        .then(result => {
+          return "Success!"
+        })
+      }
+    }
   }
 })
 

--- a/tests/requests/api/v1/graphql.spec.js
+++ b/tests/requests/api/v1/graphql.spec.js
@@ -436,4 +436,26 @@ describe('Test The Market\'s Path', () => {
       expect(res.body.data.product.vendor).toHaveProperty('id')
     })
   })
+
+  describe('GraphQL Query tests', () => {
+    it('should delete all products for a vendor', async () => {
+      const vendor = await database('vendors').select().first()
+      const queryString = `mutation{deleteAllVendorProducts(id: ${vendor.id})}`
+      let res = await request(app)
+        .post('/api/v1/graphql')
+        .send({
+          query: queryString
+        })
+      const vendor_products = await database('products').where('vendor_id', vendor.id).select()
+      const products = await database('products').select()
+
+      expect(res.statusCode).toBe(201)
+      expect(res.body).toHaveProperty('data')
+      expect(res.body.data).toHaveProperty('deleteAllVendorProducts')
+      expect(res.body.data.deleteAllVendorProducts).toBe('Success!')
+
+      expect(vendor_products.length).toBe(0)
+      expect(products.length).toBe(3)
+    })
+  })
 })


### PR DESCRIPTION
* Add a GraphQL mutation that deletes all products for a given vendor ID
* Update API documentation on the delete GraphQL mutations

closes #25 